### PR TITLE
fix: 残り時間の計算バグを修正

### DIFF
--- a/background.js
+++ b/background.js
@@ -201,8 +201,8 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
 async function handleTimerExpired() {
   debugLog('Timer expired, executing action:', currentSettings.actionOnTimeout);
   
-  const totalViewTime = timerState.elapsedTime + (timerState.startTime ? Date.now() - timerState.startTime : 0);
-  currentSettings.dailyStats.totalViewTime += totalViewTime;
+  const sessionTime = timerState.startTime ? Date.now() - timerState.startTime : 0;
+  currentSettings.dailyStats.totalViewTime += sessionTime;
   await saveSettings();
   
   if (currentSettings.actionOnTimeout === 'lock') {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "YouTube Shorts Blocker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "YouTubeショート動画の視聴時間を制限し、健全なブラウジング習慣をサポートします",
   "permissions": [
     "storage",


### PR DESCRIPTION
## 概要

タイマー期限切れ時の二重カウントバグを修正しました。

## 変更内容

- `background.js`の`handleTimerExpired()`関数で、累積時間ではなく現在のセッション時間のみを追加するように修正
- バージョンを1.0.0から1.0.1にインクリメント

Fixes #5

Generated with [Claude Code](https://claude.ai/code)