### PR TITLE
feat: add icon to popup header title

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -28,6 +28,16 @@ header h1 {
   font-size: 18px;
   font-weight: 600;
   color: #1a73e8;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.header-icon {
+  width: 24px;
+  height: 24px;
+  vertical-align: middle;
 }
 
 section {

--- a/popup.html
+++ b/popup.html
@@ -9,7 +9,7 @@
 <body>
   <div class="container">
     <header>
-      <h1>YouTube Shorts Blocker</h1>
+      <h1><img src="icons/icon32.png" alt="YouTube Shorts Blocker" class="header-icon">YouTube Shorts Blocker</h1>
     </header>
 
     <!-- タイマーセクション -->


### PR DESCRIPTION
Fixes #25

Added the extension icon to the left of the settings screen title as requested.

## Changes
- popup.htmlのヘッダーに32pxの拡張アイコンを追加。
- popup.cssをフレックスボックスレイアウトに更新し、適切な配置にした。
- アイコンは24x24pxで表示され、タイトル・テキストとは8pxのギャップがあります。

Generated with [Claude Code](https://claude.ai/code)