### PR TITLE
feat: convert temp disable button to toggle

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "YouTube Shorts Blocker",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "YouTubeショート動画の視聴時間を制限し、健全なブラウジング習慣をサポートします",
   "permissions": [
     "storage",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-shorts-blocker",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "YouTubeショート動画の視聴時間を制限し、健全なブラウジング習慣をサポートします",
   "scripts": {
     "version:patch": "npm version patch --no-git-tag-version && node scripts/sync-version.js",


### PR DESCRIPTION
Fixes #29

このセッションのみタイマーを無効にする」ボタンをトグルに変更し、誤って押してしまった場合に再度タイマーを有効にできるようにした。

## Changes
- popup.jsを更新し、現在の状態に基づいて動的なボタン・テキストを表示するようにした。
- background.js に toggleTempDisableForTab メッセージハンドラを追加した。
- 現在のタブでタイマーを無効にした後、再度タイマーを有効にできるようにした
- ボタンテキストが "タイマーを再開する" と "今回のみタイマーを起動しない" の間で変更されるようになった

Generated with [Claude Code](https://claude.ai/code)